### PR TITLE
prevent surfacing errors happening in components to be unmounted

### DIFF
--- a/src/useObservable.ts
+++ b/src/useObservable.ts
@@ -1,7 +1,15 @@
 import { useEffect, useReducer } from "react"
 import { BehaviorObservable, SUSPENSE } from "./"
 
-const reducer = (_: any, action: any) => action
+const reducer = (
+  _: any,
+  { type, payload }: { type: "next" | "error"; payload: any },
+) => {
+  if (type === "error") {
+    throw payload
+  }
+  return payload
+}
 const init = (source$: BehaviorObservable<any>) => {
   try {
     return source$.getValue()
@@ -18,11 +26,28 @@ export const useObservable = <O>(
 
   useEffect(() => {
     try {
-      dispatch(source$.getValue())
+      dispatch({
+        type: "next",
+        payload: source$.getValue(),
+      })
     } catch (e) {
-      dispatch(SUSPENSE)
+      dispatch({
+        type: "next",
+        payload: SUSPENSE,
+      })
     }
-    const subscription = source$.subscribe(dispatch)
+    const subscription = source$.subscribe(
+      value =>
+        dispatch({
+          type: "next",
+          payload: value,
+        }),
+      error =>
+        dispatch({
+          type: "error",
+          payload: error,
+        }),
+    )
     return () => subscription.unsubscribe()
   }, [source$, unsubscribeGraceTime])
 


### PR DESCRIPTION
Recently I've been thinking about a possible issue with the current re-rxjs bindings.

It has to do with possible false assumptions when using `connectFactoryObservable`. As an example, imagine we write a factory observable such as:

```ts
const [useUserPosts] = connectFactoryObservable(
  (userId: string) => user$.pipe(
    map(users => users[id]),
    map(user => user.posts),
    combineLatest(post$),
    map(([ids, posts]) => ids.map(id => posts[id]))
)
```

We might make the assumption that, as we will call `useUserPosts()` in components that receive an existing `userId`, we don't need to check whether that userId exists (again, because we're going to call this hook with existing ids).

The problem comes when a user is removed. In this logic, no error should be thrown because as the component gets unmounted, it won't be requesting an id that doesn't exist, but that's not the case because the component will get unmounted _after_ this value has computed, so the code above will throw an uncaught `can't access property 'posts' of undefined`.

Here I have a [sandbox with a simplified todomvc](https://0pkl9.codesandbox.io/) that shows the current behaviour.

_👇 Outdated, see comments below_
> This PR fixes this by catching all the errors that happen in the stream, and throwing them in a `useEffect`. This way, if react has unmounted the component, the error won't be thrown.
> 
> I don't fully like the test I've written, but it works so far. It was mostly trial-and-error until I found something that failed without the fix and works fine after it. I'll try to find something a bit better later on if needed.
> I'd also want to add a test to check that other errors are still being thrown, but I can't because any uncaught errors will cause jest to fail the test (see facebook/jest#5620).
