### PR TITLE
useObservable: remove unnecessary argument

### DIFF
--- a/src/connectFactoryObservable.ts
+++ b/src/connectFactoryObservable.ts
@@ -56,11 +56,7 @@ export function connectFactoryObservable<
     getSharedObservables$(...input)[0]
 
   return [
-    (...input: A) =>
-      useObservable(
-        getSharedObservables$(...input)[1],
-        options.unsubscribeGraceTime,
-      ),
+    (...input: A) => useObservable(getSharedObservables$(...input)[1]),
 
     getSharedObservable$,
   ]

--- a/src/useObservable.ts
+++ b/src/useObservable.ts
@@ -20,7 +20,6 @@ const init = (source$: BehaviorObservable<any>) => {
 
 export const useObservable = <O>(
   source$: BehaviorObservable<O>,
-  unsubscribeGraceTime = 200,
 ): Exclude<O, typeof SUSPENSE> => {
   const [state, dispatch] = useReducer(reducer, source$, init)
 
@@ -49,7 +48,7 @@ export const useObservable = <O>(
         }),
     )
     return () => subscription.unsubscribe()
-  }, [source$, unsubscribeGraceTime])
+  }, [source$])
 
   return state !== (SUSPENSE as any) ? (state as any) : source$.getValue()
 }


### PR DESCRIPTION
I forgot to get rid of it when we decided to stop exposing `useObservable`