### PR TITLE
Remove React-(dom/native) unstable_batchedUpdates

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,6 @@
     "react": ">=16.8.0",
     "rxjs": ">=6"
   },
-  "peerDependenciesMeta": {
-    "react-dom": {
-      "optional": true
-    },
-    "react-native": {
-      "optional": true
-    }
-  },
   "husky": {
     "hooks": {
       "pre-commit": "tsdx lint"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,3 @@
-import { setBatch } from "./utils/batch"
-import { unstable_batchedUpdates as batch } from "./utils/react-batched-updates"
-setBatch(batch as any)
-
 export const SUSPENSE = Symbol("SUSPENSE")
 export { BehaviorObservable } from "./BehaviorObservable"
 export { connectObservable } from "./connectObservable"

--- a/src/operators/distinct-share-replay.ts
+++ b/src/operators/distinct-share-replay.ts
@@ -1,6 +1,5 @@
 import { Observable, Subscription, Subject } from "rxjs"
 import { SUSPENSE, BehaviorObservable } from "../"
-import { getBatch } from "../utils/batch"
 
 function defaultTeardown() {}
 
@@ -13,7 +12,6 @@ export const distinctShareReplay = <T>(
   let subscription: Subscription | undefined
   let refCount = 0
   let currentValue: { value: T }
-  const batch = getBatch()
 
   const result = new Observable<T>(subscriber => {
     refCount++
@@ -26,9 +24,7 @@ export const distinctShareReplay = <T>(
             currentValue.value === EMPTY_VALUE ||
             !compareFn(value, currentValue.value)
           ) {
-            batch(() => {
-              subject!.next((currentValue.value = value))
-            })
+            subject!.next((currentValue.value = value))
           }
         },
         error(err) {

--- a/src/utils/batch.ts
+++ b/src/utils/batch.ts
@@ -1,8 +1,0 @@
-function defaultNoopBatch(callback: () => void) {
-  callback()
-}
-
-let batch = defaultNoopBatch
-
-export const setBatch = (newBatch: () => void) => (batch = newBatch)
-export const getBatch = () => batch

--- a/src/utils/react-batched-updates.native.ts
+++ b/src/utils/react-batched-updates.native.ts
@@ -1,3 +1,0 @@
-import { unstable_batchedUpdates } from "react-native"
-
-export { unstable_batchedUpdates }

--- a/src/utils/react-batched-updates.ts
+++ b/src/utils/react-batched-updates.ts
@@ -1,1 +1,0 @@
-export { unstable_batchedUpdates } from "react-dom"


### PR DESCRIPTION
I've been thinking a lot about this lately and I'm almost convinced that it doesn't make sense for us to use the `unstable_batchedUpdates`... The reason being that those changes that come from within react event-handlers (e.g. `onClick`) will be batched already. On the other hand, those updates that come from external sources (i.e: APIs whether they are socket-based or REST) the recommendation would be to observer them through the `asapScheduler`. In other words, it would be up to the user to decide the priority of each "event", but if this library is used as it's intended, then observing changes through the `asapScheduler` should remove the need for prematurely batching external updates.

Anyways, this is a decision that can be revisited in the future and it would only imply a patch upgrade. So, I much rather not to fall for what now I think it could be a premature optimization.