### PR TITLE
Improve distinctShareReplay

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,18 @@
+import { Observable } from "rxjs"
+import { distinctShareReplay as internalDistinctShareReplay } from "./operators/distinct-share-replay"
+
+// support for React Suspense
 export { SUSPENSE } from "./SUSPENSE"
-export { BehaviorObservable } from "./BehaviorObservable"
-export { connectObservable } from "./connectObservable"
-export { connectFactoryObservable } from "./connectFactoryObservable"
-export { distinctShareReplay } from "./operators/distinct-share-replay"
-export { createInput } from "./createInput"
 export { suspend } from "./operators/suspend"
 export { suspended } from "./operators/suspended"
 export { switchMapSuspended } from "./operators/switchMapSuspended"
+
+// core
+export { connectObservable } from "./connectObservable"
+export { connectFactoryObservable } from "./connectFactoryObservable"
+export const distinctShareReplay = internalDistinctShareReplay as <T>(
+  compareFn?: (a: T, b: T) => boolean,
+) => (source$: Observable<T>) => Observable<T>
+
+// utils
+export { createInput } from "./createInput"

--- a/test/operators/distinct-share-replay.test.ts
+++ b/test/operators/distinct-share-replay.test.ts
@@ -1,4 +1,5 @@
-import { BehaviorObservable, distinctShareReplay, SUSPENSE } from "../../src"
+import { distinctShareReplay, SUSPENSE } from "../../src"
+import { BehaviorObservable } from "../../src/BehaviorObservable"
 import { EMPTY_VALUE } from "../../src/operators/distinct-share-replay"
 import { cold } from "jest-marbles"
 import { TestScheduler } from "rxjs/testing"

--- a/test/operators/react-enhancer.test.ts
+++ b/test/operators/react-enhancer.test.ts
@@ -1,5 +1,6 @@
 import reactEnhancer from "../../src/operators/react-enhancer"
-import { BehaviorObservable, distinctShareReplay, SUSPENSE } from "../../src"
+import { distinctShareReplay, SUSPENSE } from "../../src"
+import { BehaviorObservable } from "../../src/BehaviorObservable"
 import { TestScheduler } from "rxjs/testing"
 import { Subject } from "rxjs"
 

--- a/test/useObservable.test.tsx
+++ b/test/useObservable.test.tsx
@@ -4,7 +4,8 @@ import { defer, of, Subject, NEVER, concat } from "rxjs"
 import { renderHook, act } from "@testing-library/react-hooks"
 import { useObservable } from "../src/useObservable"
 import reactEnhancer from "../src/operators/react-enhancer"
-import { SUSPENSE, BehaviorObservable, distinctShareReplay } from "../src"
+import { SUSPENSE, distinctShareReplay } from "../src"
+import { BehaviorObservable } from "../src/BehaviorObservable"
 
 const wait = (ms: number) => new Promise(res => setTimeout(res, ms))
 


### PR DESCRIPTION
As I was writing the docs I realized that the `distinctShareReplay` that we are currently exposing is leaking some internals that I rather not to leak:

- The `teardown` function is not a normal `finalize` because it only runs when the `refCount` goes down to zero, and it's meant for internal usage only. So, I rather not to expose that.
- The `BehaviorObservable` it's an internal type, there is no need for the consumers of this library to know about its existence.