### PR TITLE
docs: add usage examples to every method

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ The pipeable version of `suspend`
 
 ```ts
 const story$ = selectedStoryId$.pipe(
-  switchMapSuspended(id => getStory$(id))
+  switchMapSuspended(getStory$)
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ underlying enhanced observable, which shares the subscription to all of its subs
 and always emits the latest value when subscribing to it.
 
 The shared subscription is closed as soon as there are no subscribers to that
-hook/observable.
+observable.
 
 ### connectFactoryObservable
 ```tsx


### PR DESCRIPTION
Forgive me I was late on reviewing the initial docs PR - Here are my suggestions that I think it improves them a bit.

I understand that those were initial docs, to have something better than a placeholder, so I agree that maybe this PR should be closed instead and this will be addressed when working on the final docs. But in case they might help, here they are.

Addresses two main points:
1. I didn't fully like adding keywords that people might not be familiar with. Specifically `shared` and `replayable`. So I rephrased that.
2. Some of the operators had the actual implementation in them. Although I can see how this is useful to get the point across (e.g. `distinctShareReplay`), I felt like in some places it was redundant (if people want to see the how it's implemented it's just 2 clicks away), and it would be of more helpful to show a usage example instead.