### PR TITLE
test: updates on connectObservable, suspense

### DIFF
--- a/test/operators/suspend.test.ts
+++ b/test/operators/suspend.test.ts
@@ -1,0 +1,24 @@
+import { TestScheduler } from "rxjs/testing"
+import { suspend } from "../../src/operators/suspend"
+import { SUSPENSE } from "../../src/SUSPENSE"
+
+const scheduler = () =>
+  new TestScheduler((actual, expected) => {
+    expect(actual).toEqual(expected)
+  })
+
+describe("operators/suspend", () => {
+  it("prepends the source stream with SUSPENSE", () => {
+    scheduler().run(({ expectObservable, cold }) => {
+      const source = cold("----a")
+      const expected = "   s---a"
+
+      const suspended = suspend(source)
+
+      expectObservable(suspended).toBe(expected, {
+        s: SUSPENSE,
+        a: "a",
+      })
+    })
+  })
+})

--- a/test/operators/suspended.test.ts
+++ b/test/operators/suspended.test.ts
@@ -1,0 +1,24 @@
+import { TestScheduler } from "rxjs/testing"
+import { suspended } from "../../src/operators/suspended"
+import { SUSPENSE } from "../../src/SUSPENSE"
+
+const scheduler = () =>
+  new TestScheduler((actual, expected) => {
+    expect(actual).toEqual(expected)
+  })
+
+describe("operators/suspended", () => {
+  it("prepends the stream with SUSPENSE", () => {
+    scheduler().run(({ expectObservable, cold }) => {
+      const source = cold("----a")
+      const expected = "   s---a"
+
+      const result$ = source.pipe(suspended())
+
+      expectObservable(result$).toBe(expected, {
+        s: SUSPENSE,
+        a: "a",
+      })
+    })
+  })
+})

--- a/test/operators/switchMapSuspended.test.ts
+++ b/test/operators/switchMapSuspended.test.ts
@@ -1,0 +1,40 @@
+import { TestScheduler } from "rxjs/testing"
+import { switchMapSuspended } from "../../src/operators/switchMapSuspended"
+import { SUSPENSE } from "../../src/SUSPENSE"
+
+const scheduler = () =>
+  new TestScheduler((actual, expected) => {
+    expect(actual).toEqual(expected)
+  })
+
+describe("operators/switchMapSuspended", () => {
+  it("acts like a switchMap, but emitting a SUSPENSE when activating the inner stream", () => {
+    scheduler().run(({ expectObservable, cold }) => {
+      const source = cold("-x---")
+      const inner = cold("  ----a")
+      const expected = "   -s---a"
+
+      const result$ = source.pipe(switchMapSuspended(() => inner))
+
+      expectObservable(result$).toBe(expected, {
+        s: SUSPENSE,
+        a: "a",
+      })
+    })
+  })
+
+  it("emits another SUSPENSE when another inner stream activates", () => {
+    scheduler().run(({ expectObservable, cold }) => {
+      const source = cold("-x--x")
+      const inner = cold("     ----a")
+      const expected = "   -s--s---a"
+
+      const result$ = source.pipe(switchMapSuspended(() => inner))
+
+      expectObservable(result$).toBe(expected, {
+        s: SUSPENSE,
+        a: "a",
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR covers the rest of test improvements identified in #20 

For the "it works in suspense" what I did is in `connectObservable` cover the part where it integrates with react (by using exclusively SUSPENSE), and then all the "sugar operators" are tested in isolation.

IMPORTANT -> I made a change to `switchMapSuspended` which I think it makes it a bit smarter. I ran into that when thinking on tests for that operator.

As it's currently in main branch, if a new update comes from the source stream before the inner stream has published anything, that inner stream will get cancelled, a new SUSPENSE will be emitted and a new subscription to the inner stream will be made.

I think it would make sense for `switchMapSuspended` for only emitting one single SUSPENSE while there are no new data. I guess it doesn't hurt for it to emit more than one (or does it?), so I put this feature in a separate commit if we decide we don't want this behaviour and the commit can be dropped. Maybe you want it in another PR?